### PR TITLE
Fix RPC crash

### DIFF
--- a/src/main/java/me/xmrvizzy/skyblocker/discord/DiscordRPCManager.java
+++ b/src/main/java/me/xmrvizzy/skyblocker/discord/DiscordRPCManager.java
@@ -77,10 +77,12 @@ public class DiscordRPCManager implements IPCListener{
     }
 
     public void stop(){
-        logger.info("Closing...");
-        isConnected = false;
-        client.close();
-        client = null;
+        if (client != null){
+            logger.info("Closing...");
+            isConnected = false;
+            client.close();
+            client = null;
+        }
     }
 
     @Override


### PR DESCRIPTION
Just adds a quick check to see if the IPCClient is not null before attempting to close it